### PR TITLE
Fix bug in `Knockout.reorder_participants` that arised when number of participants was not power of 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /venv
+/.venv
 /envvars
 /deployed
 .DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Leonid Kostrykin
+Copyright (c) 2025 Leonid Kostrykin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tournaments/frontend/templates/frontend/base.html
+++ b/tournaments/frontend/templates/frontend/base.html
@@ -92,7 +92,7 @@
     
     <hr>
     <p class="text-muted"><small>
-    <b>Copyright &copy; 2024.</b>
+    <b>Copyright &copy; 2025.</b>
     {% if version %}
     Version {{ version.sha | slice:"0:7" }} {{ version.date }}.
     {% endif %}

--- a/tournaments/tournaments/models.py
+++ b/tournaments/tournaments/models.py
@@ -522,6 +522,10 @@ class Knockout(Mode):
         # Account for playoffs.
         if account_for_playoffs and not power_of_two:
 
+            # Verify that the number of participants is even.
+            if len(participants) % 2 == 1:
+                raise ValueError(f'number of knockout participants must be even')
+
             # Number of participants allocated for the playoffs.
             n = min((2 * (len(participants) - power_of_two_floor), len(participants)))
 

--- a/tournaments/tournaments/models.py
+++ b/tournaments/tournaments/models.py
@@ -5,7 +5,7 @@ import random
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
-from django.db.models import CheckConstraint, Q, Min, Max
+from django.db.models import CheckConstraint, Q, QuerySet, Min, Max
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
@@ -522,12 +522,12 @@ class Knockout(Mode):
         # Account for playoffs.
         if account_for_playoffs and not power_of_two:
 
-            # Verify that the number of participants is even.
-            if len(participants) % 2 == 1:
-                raise ValueError(f'number of knockout participants must be even')
-
             # Number of participants allocated for the playoffs.
             n = min((2 * (len(participants) - power_of_two_floor), len(participants)))
+
+            # Negative indexing is not supported on QuerySet onbjects, thus convert to list.
+            if isinstance(participants, QuerySet):
+                participants = list(participants)
 
             # Allocate the participants.
             playoffs_part = Knockout.reorder_participants(participants[-n:], account_for_playoffs = False)

--- a/tournaments/tournaments/tests.py
+++ b/tournaments/tournaments/tests.py
@@ -765,19 +765,33 @@ class GroupsTest(ModeTestBase, TestCase):
 class KnockoutTest(ModeTestBase, TestCase):
 
     def test_reorder_participants(self):
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = False, participants = []), [])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = False, participants = [1]), [1])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = False, participants = [1, 2]), [1, 2])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = False, participants = [1, 2, 3]), [1, 3, 2])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = False, participants = [1, 2, 3, 4, 5, 6]), [1, 6, 2, 5, 3, 4])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = False, participants = [1, 2, 3, 4, 5, 6, 7]), [1, 7, 2, 6, 3, 5, 4])
+        subtests = [
+            (dict(account_for_playoffs = False, participants = []), []),
+            (dict(account_for_playoffs = False, participants = [1]), [1]),
+            (dict(account_for_playoffs = False, participants = [1, 2]), [1, 2]),
+            (dict(account_for_playoffs = False, participants = [1, 2, 3]), [1, 3, 2]),
+            (dict(account_for_playoffs = False, participants = [1, 2, 3, 4, 5, 6]), [1, 6, 2, 5, 3, 4]),
+            (dict(account_for_playoffs = False, participants = [1, 2, 3, 4, 5, 6, 7]), [1, 7, 2, 6, 3, 5, 4]),
 
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = True, participants = []), [])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = True, participants = [1]), [1])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = True, participants = [1, 2]), [1, 2])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = True, participants = [1, 2, 3]), [2, 3, 1])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = True, participants = [1, 2, 3, 4, 5, 6]), [3, 6, 4, 5, 1, 2])
-        self.assertEqual(Knockout.reorder_participants(account_for_playoffs = True, participants = [1, 2, 3, 4, 5, 6, 7]), [2, 7, 3, 6, 4, 5, 1])
+            (dict(account_for_playoffs = True, participants = []), []),
+            (dict(account_for_playoffs = True, participants = [1]), [1]),
+            (dict(account_for_playoffs = True, participants = [1, 2]), [1, 2]),
+            (dict(account_for_playoffs = True, participants = [1, 2, 3]), [2, 3, 1]),
+            (dict(account_for_playoffs = True, participants = [1, 2, 3, 4, 5, 6]), [3, 6, 4, 5, 1, 2]),
+            (dict(account_for_playoffs = True, participants = [1, 2, 3, 4, 5, 6, 7]), [2, 7, 3, 6, 4, 5, 1]),
+        ]
+
+        for use_querysets in [False, True]:
+            for subtest_params, expected in subtests:
+                with self.subTest(**subtest_params, use_querysets = use_querysets):
+                    if use_querysets:
+                        subtest_params = dict(subtest_params)
+                        subtest_params['participants'] = User.objects.filter(id__in = subtest_params['participants'])
+                        expected = [
+                            User.objects.get(id = id) if id is not None else None
+                            for id in expected
+                        ]
+                    self.assertEqual(Knockout.reorder_participants(**subtest_params), expected)
 
     def test_create_fixtures_2participants(self):
         mode = Knockout.objects.create(tournament = self.tournament)
@@ -1540,13 +1554,11 @@ class TournamentTest(TestCase):
 
     def test_start_tournament3_uneven_participants(self):
         tournament = self.test_load_tournament3()
-        for n_participants in [3, 5, 7, 9, 11, 13, 15]:
+        for n_participants in [3]: #[3, 5, 7, 9, 11, 13, 15]:
             with self.subTest(n_participants = n_participants):
                 _clear_participants(tournament)
                 _add_participants(self.participants[:n_participants], tournament)
-                with self.assertRaises(ValueError) as error_ctx:
-                    tournament.update_state()
-                self.assertEqual(error_ctx.exception.args[0], 'number of knockout participants must be even')
+                tournament.update_state()
 
     def test_delete(self):
         tournament = self.test_load_tournament1()

--- a/tournaments/tournaments/tests.py
+++ b/tournaments/tournaments/tests.py
@@ -70,6 +70,18 @@ test_tournament2_yml = \
     - playoffs.placements[0]
     """
 
+test_tournament3_yml = \
+    """
+    stages:
+    -
+      id: main_round
+      name: Elimination
+      mode: knockout
+
+    podium:
+    - main_round.placements[:3]
+    """
+
 
 class split_into_groups_Test(TestCase):
 
@@ -1514,6 +1526,16 @@ class TournamentTest(TestCase):
         ]
         self.assertEqual(actual_stages, expected_stages)
         self.assertTrue(tournament.stages.all()[0].double_elimination)
+        return tournament
+
+    def test_load_tournament3(self):
+        tournament = Tournament.load(test_tournament3_yml, 'Test Cup')
+        actual_stages = [type(stage) for stage in tournament.stages.all()]
+        expected_stages = [
+            Knockout,
+        ]
+        self.assertEqual(actual_stages, expected_stages)
+        self.assertFalse(tournament.stages.all()[0].double_elimination)
         return tournament
 
     def test_delete(self):

--- a/tournaments/tournaments/tests.py
+++ b/tournaments/tournaments/tests.py
@@ -70,18 +70,6 @@ test_tournament2_yml = \
     - playoffs.placements[0]
     """
 
-test_tournament3_yml = \
-    """
-    stages:
-    -
-      id: main_round
-      name: Elimination
-      mode: knockout
-
-    podium:
-    - main_round.placements[:3]
-    """
-
 
 class split_into_groups_Test(TestCase):
 
@@ -1541,24 +1529,6 @@ class TournamentTest(TestCase):
         self.assertEqual(actual_stages, expected_stages)
         self.assertTrue(tournament.stages.all()[0].double_elimination)
         return tournament
-
-    def test_load_tournament3(self):
-        tournament = Tournament.load(test_tournament3_yml, 'Test Cup')
-        actual_stages = [type(stage) for stage in tournament.stages.all()]
-        expected_stages = [
-            Knockout,
-        ]
-        self.assertEqual(actual_stages, expected_stages)
-        self.assertFalse(tournament.stages.all()[0].double_elimination)
-        return tournament
-
-    def test_start_tournament3_uneven_participants(self):
-        tournament = self.test_load_tournament3()
-        for n_participants in [3]: #[3, 5, 7, 9, 11, 13, 15]:
-            with self.subTest(n_participants = n_participants):
-                _clear_participants(tournament)
-                _add_participants(self.participants[:n_participants], tournament)
-                tournament.update_state()
 
     def test_delete(self):
         tournament = self.test_load_tournament1()

--- a/tournaments/tournaments/tests.py
+++ b/tournaments/tournaments/tests.py
@@ -1540,8 +1540,13 @@ class TournamentTest(TestCase):
 
     def test_start_tournament3_uneven_participants(self):
         tournament = self.test_load_tournament3()
-        _add_participants(self.participants[:3], tournament)
-        tournament.update_state()
+        for n_participants in [3, 5, 7, 9, 11, 13, 15]:
+            with self.subTest(n_participants = n_participants):
+                _clear_participants(tournament)
+                _add_participants(self.participants[:n_participants], tournament)
+                with self.assertRaises(ValueError) as error_ctx:
+                    tournament.update_state()
+                self.assertEqual(error_ctx.exception.args[0], 'number of knockout participants must be even')
 
     def test_delete(self):
         tournament = self.test_load_tournament1()

--- a/tournaments/tournaments/tests.py
+++ b/tournaments/tournaments/tests.py
@@ -1538,6 +1538,11 @@ class TournamentTest(TestCase):
         self.assertFalse(tournament.stages.all()[0].double_elimination)
         return tournament
 
+    def test_start_tournament3_uneven_participants(self):
+        tournament = self.test_load_tournament3()
+        _add_participants(self.participants[:3], tournament)
+        tournament.update_state()
+
     def test_delete(self):
         tournament = self.test_load_tournament1()
         tournament.delete()


### PR DESCRIPTION
Starting a tournament that contains a knockout stage with an uneven number of participants yields the vacuous error
> Error while initializing tournament (Negative indexing is not supported.).

This was reported in #13.

This PR reproduces the error with an update of the `KnockoutTest.test_reorder_participants` test. The error occurs because negative indexing is not supported by Django's QuerySet objects, but only on the lists used in the test. The new test implementation also covers the usage of QuerySet objects instead of lists.

Finally, the bug is solved by explicitly converting QuerySet objects to lists, if negative indexing is required.

Playoffs now work as expected and are added automatically:

1. **Tournament progress screen before the playoff:**
    <img width="1121" alt="Bildschirmfoto 2025-03-12 um 15 03 56" src="https://github.com/user-attachments/assets/7d381b0d-b5b5-4908-a220-b1b4335ab967" />

2. **Tournament progress screen after the playoff:**
    <img width="1121" alt="Bildschirmfoto 2025-03-12 um 15 03 06" src="https://github.com/user-attachments/assets/47b71dbd-41bb-422b-bae4-a8965e2b1ba2" />
